### PR TITLE
Added packageRoot tag to allow generated app to have alternate package.

### DIFF
--- a/spring-cloud-dataflow-apps-generator-plugin/.checkstyle
+++ b/spring-cloud-dataflow-apps-generator-plugin/.checkstyle
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="maven-checkstyle-plugin checkstyle-validation" location="https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-apps-plugin/master/etc/checkstyle/checkstyle.xml" type="remote" description="maven-checkstyle-plugin configuration checkstyle-validation">
+    <property name="checkstyle.build.directory" value="/Users/richardlyon/Shared/workspace/samples/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/target
+								checkstyle.suppressions.file=https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-apps-plugin/master/etc/checkstyle/checkstyle-suppressions.xml
+								checkstyle.additional.suppressions.file=https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-apps-plugin/master/etc/checkstyle/checkstyle-suppressions.xml"/>
+    <property name="checkstyle.header.file" value="/Users/richardlyon/Shared/workspace/BOSS/ssil/.metadata/.plugins/org.eclipse.core.resources/.projects/spring-cloud-dataflow-apps-generator-plugin/com.basistech.m2e.code.quality.checkstyleConfigurator/checkstyle-header-checkstyle-validation.txt"/>
+    <property name="checkstyle.cache.file" value="${project_loc}/target/checkstyle-cachefile"/>
+  </local-check-config>
+  <local-check-config name="maven-checkstyle-plugin no-http-checkstyle-validation" location="https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-apps-plugin/master/etc/checkstyle/nohttp-checkstyle.xml" type="remote" description="maven-checkstyle-plugin configuration no-http-checkstyle-validation">
+    <property name="checkstyle.header.file" value="/Users/richardlyon/Shared/workspace/BOSS/ssil/.metadata/.plugins/org.eclipse.core.resources/.projects/spring-cloud-dataflow-apps-generator-plugin/com.basistech.m2e.code.quality.checkstyleConfigurator/checkstyle-header-no-http-checkstyle-validation.txt"/>
+    <property name="checkstyle.cache.file" value="${project_loc}/target/checkstyle-cachefile"/>
+  </local-check-config>
+  <fileset name="java-sources-checkstyle-validation" enabled="true" check-config-name="maven-checkstyle-plugin checkstyle-validation" local="true">
+    <file-match-pattern match-pattern="^src/test/java/.*\/.*\.java" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/main/java/.*\/.*\.java" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/main/resources/.*\.properties" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/test/resources/.*\.properties" include-pattern="true"/>
+  </fileset>
+  <fileset name="java-sources-no-http-checkstyle-validation" enabled="true" check-config-name="maven-checkstyle-plugin no-http-checkstyle-validation" local="true">
+    <file-match-pattern match-pattern="^./.*" include-pattern="true"/>
+    <file-match-pattern match-pattern="^..*.*\.idea/.*" include-pattern="false"/>
+    <file-match-pattern match-pattern="^..*.*\.git/.*" include-pattern="false"/>
+    <file-match-pattern match-pattern="^..*.*target/.*" include-pattern="false"/>
+    <file-match-pattern match-pattern="^..*.*\.log" include-pattern="false"/>
+    <file-match-pattern match-pattern="^src/main/resources/.*\.properties" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/test/resources/.*\.properties" include-pattern="true"/>
+  </fileset>
+</fileset-config>

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojo.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojo.java
@@ -120,6 +120,10 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 				this.global.getApplication().getConfigClass() : this.application.getConfigClass();
 		app.setConfigClass(applicationConfigClass); // TODO is applicationConfigClass a required parameter?
 
+		String applicationPackageRoot = StringUtils.isEmpty(this.application.getPackageRoot()) ?
+				this.global.getApplication().getPackageRoot() : this.application.getPackageRoot();
+		app.setPackageRoot(applicationPackageRoot); // optional parameter
+
 		String applicationFunctionDefinition = StringUtils.isEmpty(this.application.getFunctionDefinition()) ?
 				this.global.getApplication().getFunctionDefinition() : this.application.getFunctionDefinition();
 		app.setFunctionDefinition(applicationFunctionDefinition); //TODO is applicationFunctionDefinition required?
@@ -434,6 +438,11 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 		private String configClass;
 
 		/**
+		 * Package root to use with the application.
+		 */
+		private String packageRoot = "org.springframework.cloud.stream.app";
+
+		/**
 		 * The Spring Cloud Function definition. Could be a composition definition as well.
 		 */
 		private String functionDefinition;
@@ -510,6 +519,14 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 
 		public void setConfigClass(String configClass) {
 			this.configClass = configClass;
+		}
+
+		public String getPackageRoot() {
+			return packageRoot;
+		}
+
+		public void setPackageRoot(String appPackageRoot) {
+			this.packageRoot = appPackageRoot;
 		}
 
 		public String getFunctionDefinition() {

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/AppDefinition.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/AppDefinition.java
@@ -52,6 +52,11 @@ public class AppDefinition {
 	private String configClass;
 
 	/**
+	 * Application's package root.
+	 */
+	private String packageRoot;
+
+	/**
 	 * Spring Cloud Function defintion.
 	 */
 	private String functionDefinition;
@@ -146,6 +151,14 @@ public class AppDefinition {
 
 	public void setConfigClass(String configClass) {
 		this.configClass = configClass;
+	}
+
+	public String getPackageRoot() {
+		return packageRoot;
+	}
+
+	public void setPackageRoot(String packageRoot) {
+		this.packageRoot = packageRoot;
 	}
 
 	public String getFunctionDefinition() {

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/ProjectGenerator.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/ProjectGenerator.java
@@ -128,7 +128,8 @@ public final class ProjectGenerator {
 				capitalize(appDefinition.getType().name()),
 				capitalize(binder.getName()));
 
-		String appPackageName = String.format("org.springframework.cloud.stream.app.%s.%s.%s",
+		String appPackageName = String.format("%s.%s.%s.%s",
+				appDefinition.getPackageRoot(),
 				toPkg(appDefinition.getName()),
 				appDefinition.getType(),
 				binder.getName());

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
@@ -9,7 +9,7 @@
 		<version>{{app.springBootVersion}}</version>
 		<relativePath></relativePath>
 	</parent>
-	<groupId>org.springframework.cloud.stream.app</groupId>
+	<groupId>{{app.packageRoot}}</groupId>
 	<artifactId>{{app.name}}-{{app.type}}-{{app-binder.name}}</artifactId>
 	<version>{{app.version}}</version>
 	<name>{{app.name}}-{{app.type}}-{{app-binder.name}}</name>

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/apps-modules-pom.xml
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/apps-modules-pom.xml
@@ -3,7 +3,7 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.springframework.cloud.stream.app</groupId>
+	<groupId>{{app.packageRoot}}</groupId>
 	<artifactId>{{app.name}}-{{app.type}}-apps</artifactId>
 	<version>{{app.version}}</version>
 	<packaging>pom</packaging>

--- a/spring-cloud-dataflow-apps-generator-plugin/src/test/java/org/springframework/cloud/dataflow/app/plugin/MojoHarnessTest.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/test/java/org/springframework/cloud/dataflow/app/plugin/MojoHarnessTest.java
@@ -90,7 +90,7 @@ public class MojoHarnessTest {
 		assertThat(parent.getVersion()).isEqualTo("2.3.0.M1");
 
 		assertThat(pomModel.getArtifactId()).isEqualTo("http-source-kafka");
-		assertThat(pomModel.getGroupId()).isEqualTo("org.springframework.cloud.stream.app");
+		assertThat(pomModel.getGroupId()).isEqualTo("org.springframework.cloud.stream.app.test");
 		assertThat(pomModel.getName()).isEqualTo("http-source-kafka");
 		assertThat(pomModel.getVersion()).isEqualTo("3.0.0.BUILD-SNAPSHOT");
 		assertThat(pomModel.getDescription()).isEqualTo("Spring Cloud Stream Http Source Kafka Binder Application");

--- a/spring-cloud-dataflow-apps-generator-plugin/src/test/resources/unit/http-source-apps/pom.xml
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/test/resources/unit/http-source-apps/pom.xml
@@ -231,6 +231,7 @@
 						<type>source</type>
 						<version>${project.version}</version>
 						<configClass>io.pivotal.java.function.http.supplier.HttpSupplierConfiguration.class</configClass>
+						<packageRoot>org.springframework.cloud.stream.app.test</packageRoot>
 
 						<properties>
 							<spring.main.web-application-type>reactive</spring.main.web-application-type>


### PR DESCRIPTION
Added packageRoot plugin tag to allow generated app to have alternate package.

If packageRoot is provided, the value is used as the maven groupId as well
as the base package for the generated packageName in the generator.
If no packageRoot is provided, the default is "org.springframework.cloud.stream.app",
which allows for backward compatibility of the current apps.

Sample:

<application>
    <name>http</name>
    <type>source</type>
    <version>${project.version}</version>
    <configClass>io.pivotal.java.function.http.supplier.HttpSupplierConfiguration.class</configClass>
    <packageRoot>org.springframework.cloud.stream.app.test</packageRoot>
    <......>