### PR TITLE
Enable custom Spring Boot Maven plugin config

### DIFF
--- a/spring-cloud-dataflow-apps-generator-plugin/README.adoc
+++ b/spring-cloud-dataflow-apps-generator-plugin/README.adoc
@@ -253,3 +253,50 @@ binders and to your binders section configuration like this:
 ...
 </binders>
 ----
+
+== Custom Spring Boot Maven Plugin Configuration
+
+Spring Boot Maven plugin offers a number of customization options by specifying a configuration section in the plugin definition.
+For example, using the custom configuration, you can instruct the plugin to unpack a particular dependency.
+You would do that using Spring Boot Maven plugin as below.
+```
+<plugin>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-maven-plugin</artifactId>
+    <configuration>
+        <requiresUnpack>
+                    <dependency>
+                        <groupId>org.python</groupId>
+                        <artifactId>jython-standalone</artifactId>
+                    </dependency>
+                </requiresUnpack>
+    </configuration>
+</plugin>
+```
+
+When using the app generator plugin, you can ask the plugin to include this information when it generates the necessary XML snippets for adding the Spring Boot Maven plugin.
+Below is an example of doing so.
+```
+<plugin>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-dataflow-apps-generator-plugin</artifactId>
+    <configuration>
+        <application>
+            ...
+            <bootPluginConfiguration>
+                <![CDATA[
+                <requiresUnpack>
+                    <dependency>
+                        <groupId>org.python</groupId>
+                        <artifactId>jython-standalone</artifactId>
+                    </dependency>
+                </requiresUnpack>
+                ]]>
+            </bootPluginConfiguration>
+            ...
+        </application>
+    </configuration>
+```
+
+Pay attention to how the Spring Boot plugin configuration is wrapped inside a `CDATA` element.
+This is necessary for the app generator to properly parse this information.

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojo.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Christian Tzolov
  * @author David Turanski
+ * @author Soby Chacko
  */
 @Mojo(name = "generate-app")
 public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
@@ -305,6 +306,8 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 				})
 				.collect(Collectors.toList());
 
+		app.setBootPluginConfiguration(this.application.getBootPluginConfiguration());
+
 		// ----------------------------------------------------------------------------------------------------------
 		//                                 Project Generator
 		// ----------------------------------------------------------------------------------------------------------
@@ -460,6 +463,16 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 		private final ContainerImage containerImage = new ContainerImage();
 
 		private final Maven maven = new Maven();
+
+		private String bootPluginConfiguration;
+
+		public String getBootPluginConfiguration() {
+			return bootPluginConfiguration;
+		}
+
+		public void setBootPluginConfiguration(String bootPluginConfiguration) {
+			this.bootPluginConfiguration = bootPluginConfiguration;
+		}
 
 		public Map<String, String> getProperties() {
 			return properties;

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/AppDefinition.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/AppDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.List;
  * Application configurations used to parameterize the project templates.
  *
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 public class AppDefinition {
 
@@ -80,6 +81,16 @@ public class AppDefinition {
 	 * Application metadata related configurations to be applied for this App definition.
 	 */
 	private final Metadata metadata = new Metadata();
+
+	private String bootPluginConfiguration;
+
+	public String getBootPluginConfiguration() {
+		return bootPluginConfiguration;
+	}
+
+	public void setBootPluginConfiguration(String bootPluginConfiguration) {
+		this.bootPluginConfiguration = bootPluginConfiguration;
+	}
 
 	public String getName() {
 		return name;

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
@@ -134,6 +134,11 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				{{#app.bootPluginConfiguration}}
+				<configuration>
+					{{this}}
+				</configuration>
+				{{/app.bootPluginConfiguration}}
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
Allow user applications to provide custom Spring Boot Maven
plugin configuration. The app generator plugin takes these
custom configuration elements, which are provided as CDATA,
and then add it to the Spring Boot Maven plugin configuration
when it generates app's Maven configuration (pom.xml).

Adding tests and docs.