### PR TITLE
Remove 'latest' tag from jib docker image

### DIFF
--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
@@ -150,10 +150,7 @@
 						<image>{{app.containerImage.baseImage}}</image>
 					</from>
 					<to>
-						<image>{{app.containerImage.orgName}}/${project.artifactId}</image>
-						<tags>
-							<tag>{{app.containerImage.tag}}</tag>
-						</tags>
+						<image>{{app.containerImage.orgName}}/${project.artifactId}:${{app.containerImage.tag}}</image>
 					</to>
 					<container>
 						<creationTime>USE_CURRENT_TIMESTAMP</creationTime>


### PR DESCRIPTION
Before this change, the JIB produced image would have the following tags:
- `latest`
- `${project.version}`

This change remove the latest tag. 

The motivation is around the stream-applications CI builds. The `latest` tag is now ambiguous since there are multiple build branches building/pushing images marked as `latest`. 

The build has also been modified to take this into account https://github.com/spring-cloud/stream-applications/pull/229