### PR TITLE
Gh 23 add Auto-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dump.rdb
 coverage-error.log
 .apt_generated
 aws.credentials.properties
+.vscode/
+

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-dataflow-apps-plugin-parent</artifactId>
-	<version>1.0.7</version>
+	<version>1.0.8-SNAPSHOT</version>
 	<name>spring-cloud-dataflow-apps-plugin-parent</name>
 	<description>Spring Cloud Dataflow Apps Plugin Parent</description>
 	<packaging>pom</packaging>

--- a/spring-cloud-dataflow-apps-docs-plugin/pom.xml
+++ b/spring-cloud-dataflow-apps-docs-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-apps-plugin-parent</artifactId>
-		<version>1.0.7</version>
+		<version>1.0.8-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-dataflow-apps-generator-plugin/pom.xml
+++ b/spring-cloud-dataflow-apps-generator-plugin/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spring-cloud-dataflow-apps-generator-plugin</artifactId>
@@ -9,16 +10,17 @@
   <parent>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-dataflow-apps-plugin-parent</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.6.3</maven.version>
-    <maven.plugin.version>3.6.0</maven.plugin.version>
+    <maven.version>3.9.2</maven.version>
+    <maven.plugin.version>3.9.0</maven.plugin.version>
     <jmustache.version>1.15</jmustache.version>
-    <spring.version>5.2.8.RELEASE</spring.version>
+    <spring.version>6.0.8</spring.version>
+    <commons.io.version>2.12.0</commons.io.version>
   </properties>
 
   <dependencies>
@@ -51,6 +53,13 @@
       <version>${maven.plugin.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons.io.version}</version>
+    </dependency>
+
 
     <dependency>
       <groupId>junit</groupId>

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/AppDefinition.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/generator/AppDefinition.java
@@ -28,6 +28,12 @@ import java.util.List;
 public class AppDefinition {
 
 	/**
+	 * Marker 'configClass' value that indicates that this is an autoconfiguration and the @Import statement should be
+	 * dropped.
+	 */
+	public static final String AUTOCONFIGURATION_MARKER = "AUTOCONFIGURATION";
+
+	/**
 	 * Application name.
 	 */
 	private String name;
@@ -156,6 +162,10 @@ public class AppDefinition {
 		return type == AppType.processor;
 	}
 
+	public boolean isAutoconfiguration() {
+		return AUTOCONFIGURATION_MARKER.equalsIgnoreCase(configClass.trim());
+	}
+
 	public String getConfigClass() {
 		return configClass;
 	}
@@ -213,8 +223,7 @@ public class AppDefinition {
 		private ContainerImageFormat format = ContainerImageFormat.Docker;
 
 		/**
-		 * True will attempt to inline the (white) filtered Spring Boot metadata as Base64 encoded
-		 * property.
+		 * True will attempt to inline the (white) filtered Spring Boot metadata as Base64 encoded property.
 		 */
 		private boolean enableMetadata = false;
 

--- a/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/App.java
+++ b/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/App.java
@@ -22,7 +22,9 @@ import org.springframework.context.annotation.Import;
 
 
 @SpringBootApplication
+{{^app.autoconfiguration}}
 @Import({ {{app.configClass}} })
+{{/app.autoconfiguration}}
 public class {{app-class-name}} {
 
 	public static void main(String[] args) {

--- a/spring-cloud-dataflow-apps-metadata-plugin/pom.xml
+++ b/spring-cloud-dataflow-apps-metadata-plugin/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-apps-plugin-parent</artifactId>
-		<version>1.0.7</version>
+		<version>1.0.8-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 


### PR DESCRIPTION
Introduce a special marker value for the `configClass` attributed: `AUTOCONFIGURATION`. 
If set it generates an app without  the `@Import` statement. 

```xml
<plugin>
  <groupId>org.springframework.cloud</groupId>
  <artifactId>spring-cloud-dataflow-apps-generator-plugin</artifactId>
  <configuration>
	  <application>
		  <name>debezium</name>
		  <type>source</type>
		  <configClass>AUTOCONFIGURATION</configClass>
...
```

Also updates some outdated dependecies.
